### PR TITLE
build gfortran in macos_arm

### DIFF
--- a/.github/workflows/scripts/macos_arm.bash
+++ b/.github/workflows/scripts/macos_arm.bash
@@ -3,8 +3,24 @@ mkdir /usr/local/include/boost
 brew install boost
 export MACOSX_DEPLOYMENT_TARGET=11.0
 export DEVELOPER_DIR=/Applications/Xcode_14.3.1.app/Contents/Developer
-export FC=/opt/homebrew/bin/gfortran-13
-export DYLD_LIBRARY_PATH=$GITHUB_WORKSPACE/scip_install/lib
+export DYLD_LIBRARY_PATH=$GITHUB_WORKSPACE/scip_install/lib:$HOME/gcc/lib
+
+
+curl -O https://ftp.gwdg.de/pub/misc/gcc/releases/gcc-14.2.0/gcc-14.2.0.tar.xz
+curl -O https://raw.githubusercontent.com/Homebrew/formula-patches/d5dcb918a951b2dcf2d7702db75eb29ef144f614/gcc/gcc-14.2.0.diff
+tar xJf gcc-14.2.0.tar.xz
+
+pushd gcc-14.2.0
+./contrib/download_prerequisites
+patch -p1 < ../gcc-14.2.0.diff
+
+./configure --prefix=$HOME/gcc --enable-checking=release --enable-languages="fortran" --disable-multilib --disable-nls --with-sysroot=/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk CC=clang CXX=clang++
+
+make -j8
+make install
+export FC=$HOME/gcc/bin/gfortran
+popd
+
 
 wget https://boostorg.jfrog.io/artifactory/main/release/1.82.0/source/boost_1_82_0.tar.bz2
 tar --bzip2 -xf $GITHUB_WORKSPACE/boost_1_82_0.tar.bz2


### PR DESCRIPTION
This adds a build of gfortran to the macos_arm job.
The libs build there should require only macOS 11.

I don't see where you redistribute the libs, though. Maybe I didn't really understood the original problem.

The "solution" from this PR is of course not nice. It makes the job run very long. Feel free to just close it.

Here is a log from running the job: https://productionresultssa10.blob.core.windows.net/actions-results/55f4b8b7-2851-435f-813e-2455e24dc47e/workflow-job-run-fcf18aec-d6fd-5643-497a-0979a2df1282/logs/job/job-logs.txt?rsct=text%2Fplain&se=2024-10-03T08%3A44%3A56Z&sig=Y09j4ZyqnR4e%2B%2BFxvi0U9JsKnrw0jFm224z1il4QvuQ%3D&ske=2024-10-03T17%3A39%3A19Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2024-10-03T05%3A39%3A19Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2024-08-04&sp=r&spr=https&sr=b&st=2024-10-03T08%3A34%3A51Z&sv=2024-08-04
(It looks like the SCIP build failed, but the SCIP tests still succeeded.)


