### PR TITLE
Use clang compiler for gcg on macos x86_64

### DIFF
--- a/.github/workflows/scripts/macos.bash
+++ b/.github/workflows/scripts/macos.bash
@@ -88,7 +88,7 @@ unzip v$GCG_VERSION.zip
 cd gcg-$GCG_VERSION
 mkdir build
 cd build
-cmake .. -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/scip_install -DCMAKE_BUILD_TYPE=Release -DGMP=false -DSYM=none
+cmake .. -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/scip_install -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++ -DCMAKE_BUILD_TYPE=Release -DGMP=false -DSYM=none
 make -j
 make test
 make install

--- a/.github/workflows/scripts/macos_arm.bash
+++ b/.github/workflows/scripts/macos_arm.bash
@@ -2,7 +2,7 @@ rm -rf /usr/local/include/boost
 mkdir /usr/local/include/boost
 brew install boost
 export MACOSX_DEPLOYMENT_TARGET=14.0
-export DEVELOPER_DIR=/Applications/Xcode_14.3.1.app/Contents/Developer
+export DEVELOPER_DIR=/Applications/Xcode_15.0.1.app/Contents/Developer
 export FC=/opt/homebrew/bin/gfortran-13
 export DYLD_LIBRARY_PATH=$GITHUB_WORKSPACE/scip_install/lib
 


### PR DESCRIPTION
When building pygcgopt with these libraries on macos x86_64 I receive an error that one symbol does not exist (https://github.com/scipopt/PyGCGOpt/actions/runs/12079075971/job/33684420210). I don't get this error on macos arm64. I researched this issue and it is probably because the shared library libgcg is build with gcc and g++ and not with clang and clang++. This should fix the issue.
And fixes macos arm64 build.