### PR TITLE
Add Linux on ARM

### DIFF
--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -213,7 +213,7 @@ jobs:
     linux-arm-build-binaries:
         runs-on: ubuntu-24.04-arm
         if: github.event.inputs.linux == 'true'
-        container: quay.io/pypa/manylinux_2_39_aarch64
+        container: quay.io/pypa/manylinux_2_28_aarch64
         steps:
           - uses: actions/checkout@v4
           - name: Build and install SCIP

--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -210,6 +210,40 @@ jobs:
                 name: linux
                 path: ${{ github.workspace }}/libscip-linux.zip
 
+    linux-arm-build-binaries:
+        runs-on: ubuntu-24.04-arm
+        if: github.event.inputs.linux == 'true'
+        container: quay.io/pypa/manylinux_2_39_aarch64
+        steps:
+          - uses: actions/checkout@v4
+          - name: Build and install SCIP
+            run: |
+              export SCIP_VERSION=$(echo "${{github.event.inputs.scip_version}}" | tr -d '.')
+              export GCG_VERSION=$(echo "${{github.event.inputs.gcg_version}}" | tr -d '.')
+              export SOPLEX_VERSION=$(echo "${{github.event.inputs.soplex_version}}" | tr -d '.')
+              export IPOPT_VERSION=${{ github.event.inputs.ipopt_version }}
+              if [ "${{github.event.inputs.debug}}" = "true" ]; then
+                  export BUILD_MODE=Debug
+              else
+                  export BUILD_MODE=Release
+              fi
+              if [ "${{github.event.inputs.static}}" = "true" ]; then
+                  export SHARED=OFF
+              else
+                  export SHARED=ON
+              fi
+              if [ "${{github.event.inputs.use_cached_dependencies}}" = "true" ]; then
+                  export USE_CACHED_DEPENDENCIES=OFF
+              else
+                  export USE_CACHED_DEPENDENCIES=ON
+              fi
+              
+              bash -x .github/workflows/scripts/linux.bash
+          - uses: actions/upload-artifact@v4
+            with:
+              name: linux
+              path: ${{ github.workspace }}/libscip-linux-arm.zip
+
     windows-build-binaries:
         runs-on: windows-latest
         if: github.event.inputs.windows == 'true'
@@ -249,7 +283,7 @@ jobs:
 
     merge_artifacts:
       name: Merge Artifacts
-      needs: [ windows-build-binaries, linux-build-binaries, macos-intel-build-binaries, macos-arm-build-binaries ]
+      needs: [ windows-build-binaries, linux-build-binaries, linux-arm-build-binaries, macos-intel-build-binaries, macos-arm-build-binaries ]
       runs-on: ubuntu-latest
       steps:
         - name: Merge Artifacts

--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -241,7 +241,7 @@ jobs:
               bash -x .github/workflows/scripts/linux_arm.bash
           - uses: actions/upload-artifact@v4
             with:
-              name: linux
+              name: linux-arm
               path: ${{ github.workspace }}/libscip-linux-arm.zip
 
     windows-build-binaries:

--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -238,7 +238,7 @@ jobs:
                   export USE_CACHED_DEPENDENCIES=ON
               fi
               
-              bash -x .github/workflows/scripts/linux.bash
+              bash -x .github/workflows/scripts/linux_arm.bash
           - uses: actions/upload-artifact@v4
             with:
               name: linux

--- a/.github/workflows/scripts/linux.bash
+++ b/.github/workflows/scripts/linux.bash
@@ -121,4 +121,4 @@ cd $GITHUB_WORKSPACE
 mkdir -p scip_install/lib
 rm -rf scip_install/lib64/cmake
 mv scip_install/lib64/* scip_install/lib/.
-zip -r $GITHUB_WORKSPACE/libscip-linux-arm.zip scip_install/lib scip_install/include scip_install/bin
+zip -r $GITHUB_WORKSPACE/libscip-linux.zip scip_install/lib scip_install/include scip_install/bin

--- a/.github/workflows/scripts/linux_arm.bash
+++ b/.github/workflows/scripts/linux_arm.bash
@@ -34,7 +34,7 @@ enable_sipopt=no
 with_pic=yes
 with_metis_cflags=\"-I${GITHUB_WORKSPACE}/metis/include/\"
 with_metis_lflags=\"-L${GITHUB_WORKSPACE}/metis/lib -lmetis -lm\"
-with_lapack_lflags=\"-llapack_pic -lblas -lgfortran -lquadmath -lm\"
+with_lapack_lflags=\"-llapack_pic -lblas -lgfortran -lm\"
 LT_LDFLAGS=-all-static
 LDFLAGS=-static" > $GITHUB_WORKSPACE/scip_install/share/config.site
 

--- a/.github/workflows/scripts/linux_arm.bash
+++ b/.github/workflows/scripts/linux_arm.bash
@@ -121,4 +121,4 @@ cd $GITHUB_WORKSPACE
 mkdir -p scip_install/lib
 rm -rf scip_install/lib64/cmake
 mv scip_install/lib64/* scip_install/lib/.
-zip -r $GITHUB_WORKSPACE/libscip-linux-arm.zip scip_install/lib scip_install/include scip_install/bin
+zip -r $GITHUB_WORKSPACE/libscip-linux.zip scip_install/lib scip_install/include scip_install/bin

--- a/.github/workflows/scripts/linux_arm.bash
+++ b/.github/workflows/scripts/linux_arm.bash
@@ -121,4 +121,4 @@ cd $GITHUB_WORKSPACE
 mkdir -p scip_install/lib
 rm -rf scip_install/lib64/cmake
 mv scip_install/lib64/* scip_install/lib/.
-zip -r $GITHUB_WORKSPACE/libscip-linux.zip scip_install/lib scip_install/include scip_install/bin
+zip -r $GITHUB_WORKSPACE/libscip-linux-arm.zip scip_install/lib scip_install/include scip_install/bin


### PR DESCRIPTION
Resolves https://github.com/scipopt/scipoptsuite-deploy/issues/7

Difference between linux and linux-arm is that I had to remove `-lquadmath` from the LAPACK build args for linux-arm.  Not exactly certain what is the impact of this.

Build run here: https://github.com/dpostolovski/scipoptsuite-deploy/actions/runs/16835806309